### PR TITLE
Fixed ts compiler errors

### DIFF
--- a/lib/named-js-regexp.d.ts
+++ b/lib/named-js-regexp.d.ts
@@ -8,7 +8,7 @@ declare module "named-js-regexp" {
 		exec(expression: string): NamedRegExpExecArray | null;
 		execGroups(expression: string, all?: boolean): object;
 		groupsIndices(): object;
-		replace(text: string, replacement: string | ((this: NamedRegExpExecArray | null, match?, ...params) => string));
+		replace(text: string, replacement: string | ((this: NamedRegExpExecArray | null, match?: any, ...params: any[]) => string)): any;
 	}
 
 	let createNamedRegexp: (pattern: string | RegExp | boolean, flags?: string) => NamedRegExp;


### PR DESCRIPTION
Fixed below errors:
"node_modules/named-js-regexp/lib/named-js-regexp.d.ts(11,3): error TS7010: 'replace', which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/named-js-regexp/lib/named-js-regexp.d.ts(11,84): error TS7006: Parameter 'match' implicitly has an 'any' type.
node_modules/named-js-regexp/lib/named-js-regexp.d.ts(11,92): error TS7019: Rest parameter 'params' implicitly has an 'any[]' type."